### PR TITLE
Maintenance/fix readme and sql references

### DIFF
--- a/db/new.sql
+++ b/db/new.sql
@@ -1222,7 +1222,7 @@ ALTER TABLE ONLY public.continuation_responses
 --
 
 ALTER TABLE ONLY public.new_turns
-    ADD CONSTRAINT new_turns_user_id_season_day_key UNIQUE (user_id, turn_id);
+    ADD CONSTRAINT new_turns_user_id_season_day_key UNIQUE (user_id, id);
 
 
 --

--- a/documentation/getting_started.md
+++ b/documentation/getting_started.md
@@ -96,7 +96,7 @@ First, we'll create a new database and user named `risk` (if you're not familiar
 create database risk;
 create user risk with password '%password%';
 ```
-3. Now we will run `psql risk -f up.sql`. You will need to know to where you downloaded Rust-Risk, and navigate to it (on Command Prompt, `cd C:\Users\{{your user}}\Projects\Risk\db`, on POSIX Shell, `cd $HOME/Projects/Risk/db/`). Then `psql risk -f upp.sql` (it may require you login, in which case append `-U risk -p %password%` again substituting your password for %password%).
+3. Now we will run `psql risk -f new.sql`. You will need to know to where you downloaded Rust-Risk, and navigate to it (on Command Prompt, `cd C:\Users\{{your user}}\Projects\Risk\db`, on POSIX Shell, `cd $HOME/Projects/Risk/db/`). Then `psql risk -f new.sql` (it may require you login, in which case append `-U risk -p %password%` again substituting your password for %password%).
 4. The step above should complete without errors. If it argues about Citext or something else, feel free to contact me or look into it on your search engine of choice.
 
 ### Territories and Map Setup


### PR DESCRIPTION
- Fixed `public.new_turns` constraint `new_turns_user_id_season_day_key` to use the `id` column, as the `turn_id` column does not exist
- Fixed reference to initial SQL file that builds the database, from `up.sql` -> `new.sql`